### PR TITLE
ET-12672 - passing tmax value to PulsePoint bidder

### DIFF
--- a/modules/pulsepointBidAdapter.js
+++ b/modules/pulsepointBidAdapter.js
@@ -16,6 +16,7 @@ const DEFAULT_BID_TTL = 20;
 const DEFAULT_CURRENCY = 'USD';
 const DEFAULT_NET_REVENUE = true;
 const KNOWN_PARAMS = ['cp', 'ct', 'cf', 'video', 'battr', 'bcat', 'badv', 'bidfloor'];
+const DEFAULT_TMAX = 300;
 
 /**
  * PulsePoint Bid Adapter.
@@ -54,6 +55,7 @@ export const spec = {
       user: user(bidRequests[0], bidderRequest),
       regs: regs(bidderRequest),
       source: source(bidRequests[0].schain),
+      tmax: bidderRequest.timeout || DEFAULT_TMAX,
     };
     return {
       method: 'POST',

--- a/test/spec/modules/pulsepointBidAdapter_spec.js
+++ b/test/spec/modules/pulsepointBidAdapter_spec.js
@@ -2,7 +2,6 @@
 import {expect} from 'chai';
 import {spec} from 'modules/pulsepointBidAdapter.js';
 import {deepClone} from 'src/utils.js';
-import { config } from 'src/config.js';
 
 describe('PulsePoint Adapter Tests', function () {
   const slotConfigs = [{
@@ -225,6 +224,8 @@ describe('PulsePoint Adapter Tests', function () {
     expect(ortbRequest.imp[1].banner).to.not.equal(null);
     expect(ortbRequest.imp[1].banner.w).to.equal(728);
     expect(ortbRequest.imp[1].banner.h).to.equal(90);
+    // tmax
+    expect(ortbRequest.tmax).to.equal(300);
   });
 
   it('Verify parse response', function () {
@@ -917,5 +918,14 @@ describe('PulsePoint Adapter Tests', function () {
         adUnitSpecificAttribute: '123'
       }
     });
+  });
+
+  it('Verify bid request timeouts', function() {
+    const mkRequest = (bidderRequest) => spec.buildRequests(slotConfigs, bidderRequest).data;
+    // assert default is used when no bidderRequest.timeout value is available
+    expect(mkRequest(bidderRequest).tmax).to.equal(300)
+
+    // assert bidderRequest value is used when available
+    expect(mkRequest(Object.assign({},{timeout: 6000},bidderRequest)).tmax).to.equal(6000)
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This PR adds support for the OpenRTB tmax property to PulsePoint bidder requests.
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
